### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Output is now `outputs.result`
-- [CI] Replace deprecated `::set-output`
 
 ### Fixed
 - Multi-line output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Output is now `outputs.result`
+- [CI] Replace deprecated `::set-output`
 
 ### Fixed
 - Multi-line output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ output=$(changelog $@)
 output="${output//'%'/'%25'}"
 output="${output//$'\n'/'%0A'}"
 output="${output//$'\r'/'%0D'}"
-echo "::set-output name=result::$output"
+echo "result=$output" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### 🤔 What's changed?

As per the deprecation warning and explanation at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ⚡️ What's your motivation? 

See https://github.com/cucumber/common/issues/2150

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is the changelog entry fine this way?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
